### PR TITLE
Fixing link to the spec in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: CC0-1.0
 
 # ssb-http-auth-client
 
-Plugin that implements [Sign-in with SSB](https://ssb-ngi-pointer.github.io/rooms2/#sign-in-with-ssb) (primarily to the web dashboard of SSB servers, such as rooms and others) on the client-side. This is supposed to be installed and used on **apps** that make remote calls to servers, thus *clients*.
+Plugin that implements [Sign-in with SSB](https://ssbc.github.io/rooms2/#sign-in-with-ssb) (primarily to the web dashboard of SSB servers, such as rooms and others) on the client-side. This is supposed to be installed and used on **apps** that make remote calls to servers, thus *clients*.
 
 ## Installation
 


### PR DESCRIPTION
When the repos for this and the spec were moved from the ssb-ngi-pointer github project to ssbc, the link to the spec broke. This fixes that. 